### PR TITLE
HTTP: Feature - Add new asset configuration option to specify which http method to use for test connectivity

### DIFF
--- a/http.json
+++ b/http.json
@@ -77,6 +77,12 @@
             "data_type": "numeric",
             "order": 10,
             "description": "Timeout for HTTP calls"
+        },
+        "test_http_method": {
+            "data_type": "string",
+            "order": 11,
+            "description": "HTTP Method for Test Connectivity.",
+            "default": "GET"
         }
     },
     "actions": [

--- a/http_connector.py
+++ b/http_connector.py
@@ -149,6 +149,11 @@ class HttpConnector(BaseConnector):
 
         self._username = config.get('username')
         self._password = config.get('password', '')
+        self._test_http_method = config.get('test_http_method', 'get').lower()
+
+        http_methods = ('get', 'head', 'post', 'put', 'delete', 'options', 'trace', 'patch')
+        if self._test_http_method not in http_methods:
+            return self.set_status(phantom.APP_ERROR, "Given HTTP method is invalid: {0}".format(self._test_http_method))
 
         self._oauth_token_url = config.get('oauth_token_url')
         if self._oauth_token_url:
@@ -468,10 +473,10 @@ class HttpConnector(BaseConnector):
 
         if test_path:
             self.save_progress("Querying base url, {0}{1}, to test credentials".format(self._base_url, self._test_path))
-            ret_val = self._make_http_call(action_result, test_path)
+            ret_val = self._make_http_call(action_result, test_path, method=self._test_http_method)
         else:
             self.save_progress("Querying base url, {0}, to test credentials".format(self._base_url))
-            ret_val = self._make_http_call(action_result)
+            ret_val = self._make_http_call(action_result, method=self._test_http_method)
 
         if phantom.is_fail(ret_val):
             self.save_progress("Test Connectivity Failed")


### PR DESCRIPTION
## Pull Request Checklist


#### Please check the type of change your PR introduces:
- [ ] New App
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation
- [ ] Other (please describe): 

## Release Notes (REQUIRED)
- Add new asset configuration option to enable the **test connectivity** action to send non-GET requests (eg. a PUT).

## What is the current behavior? (OPTIONAL)
- **test connectivity** can only check using a GET request, which may not work for every HTTP endpoint

## What is the new behavior? (OPTIONAL)
- Allow modifying http request to issue requests with any http verb