### PR TITLE
http: Bugfix - Fix a bug where expired oauth tokens will never be refreshed

### DIFF
--- a/http_connector.py
+++ b/http_connector.py
@@ -452,8 +452,11 @@ class HttpConnector(BaseConnector):
                 endpoint=endpoint,
                 method=method,
                 headers=headers,
+                params=params,
                 verify=verify,
                 data=data,
+                files=files,
+                use_default_endpoint=use_default_endpoint,
             )
 
         # Return success for get headers action as it returns empty response body

--- a/http_connector.py
+++ b/http_connector.py
@@ -444,6 +444,7 @@ class HttpConnector(BaseConnector):
         # fetch new token if old one has expired
         if access_token and r.status_code == 401 and self.access_token_retry:
             self.save_progress("Got error: {}".format(r.status_code))
+            self._access_token = None
             self._state.pop("access_token")
             self.access_token_retry = False  # make it to false to avoid getting access token after one time (prevents recursive loop)
             return self._make_http_call(

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Fix a bug where expired access tokens cannot be refreshed [PAPP-34185]
+* Fix a bug where not all request parameters were honored while refrehsing the access token [PAPP-34185]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Fix a bug where expired access tokens cannot be refreshed [PAPP-34185]


### PR DESCRIPTION
Please ensure your pull request (PR) adheres to the following guidelines:

- Please refer to our contributing documentation for any questions on submitting a pull request, link: [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md)

## Pull Request Checklist

#### Please check if your PR fulfills the following requirements:
- [X] Testing of all the changes has been performed (for bug fixes / features)
- [X] The manual_readme_content.md has been reviewed and added / updated if needed (for bug fixes / features)
- [X] Use the following format for the PR description: `<App Name>: <PR Type> - <PR Description>`
- [X] Provide release notes as part of the PR submission which describe high level points about the changes for the upcoming GA release.
- [X] Verify all checks are passing.
- [X] Do NOT use the `next` branch of the forked repo. Create separate feature branch for raising the PR.
- [X] Do NOT submit updates to dependencies unless it fixes an issue.
## Pull Request Type

#### Please check the type of change your PR introduces:
- [ ] New App
- [X] Bugfix
- [ ] Feature
- [X] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation
- [ ] Other (please describe):

## Security Considerations (REQUIRED)
- [X] If you are exposing any endpoints using a [REST handler](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers),
  please document them in the `manual_readme_content.md`.
    - N/A
- [X] If this is a new connector or you are adding new actions
    - N/A
- [X] Are you introducing any new cryptography modules? If yes, please elaborate their purpose:
    - N/A
- [X] Are you are accessing the file system? If yes, please verify that you are only accessing paths returned through
the [Vault](https://docs.splunk.com/Documentation/SOARonprem/5.2.1/DevelopApps/AppDevAPIRef#Vault) API.
    - N/A
- [X] Are you are marking code to be ignored by Semgrep with [`nosemgrep`](https://semgrep.dev/docs/ignoring-files-folders-code/#ignoring-code-through-nosemgrep)?
    - N/A

## Release Notes (REQUIRED)
- Fix a bug where expired OAuth tokens will never be refreshed
- Fix a bug where not all request parameters get passed in while refreshing the OAuth token

## What is the current behavior? (OPTIONAL)
- An expired OAuth token is kept in cache, causing the HTTP library to assume it is valid and not attempt to refresh it. This results in requests failing after the token expires.
- If the OAuth token must be refreshed before making a request, the `params`, `files`, and `use_default_endpoint` arguments to that request are dropped.

## What is the new behavior? (OPTIONAL)
- We now remove the OAuth token once we notice it is expired, triggering the HTTP client to refresh it.
- All arguments are respected in all cases.

---
Thanks for contributing!
